### PR TITLE
Store multiple Artists with Track Entity

### DIFF
--- a/musync/entity/track.py
+++ b/musync/entity/track.py
@@ -13,41 +13,55 @@ from musync.entity.origin import Origin
 @dataclass
 class Track:
     track_id: str
-    artist_id: str
+    artist_ids: list[str]
     name: str
     date_added: Optional[dt]  # relates to playlist, requires better structure
     origin: Origin = Origin.UNKNOWN
 
     @classmethod
     def from_spotify(cls, track: dict) -> Track:
+        track_id = "" if track["track"]["id"] is None else track["track"]["id"]
+        artist_ids = (
+            []
+            if track["track"]["artists"] is None
+            else [str(t["id"]) for t in track["track"]["artists"]]
+        )
+        name = "" if track["track"]["name"] is None else track["track"]["name"]
+        date_added = (
+            None
+            if track["added_at"] is None
+            else dt.strptime(track["added_at"], "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=pytz.utc
+            )
+        )
+
         return cls(
-            track_id=track["track"]["id"],
-            artist_id=track["track"]["artists"][0]["id"],
-            name=track["track"]["name"],
-            date_added=(
-                None
-                if track["added_at"] is None
-                else dt.strptime(track["added_at"], "%Y-%m-%dT%H:%M:%SZ").replace(
-                    tzinfo=pytz.utc
-                )
-            ),
+            track_id=track_id,
+            artist_ids=artist_ids,
+            name=name,
+            date_added=date_added,
             origin=Origin.SPOTIFY,
         )
 
     @classmethod
     def from_tidal(cls, track: tidal.Track) -> Track:
+        track_id = "" if track.id is None else str(track.id)
+        artist_ids = (
+            []
+            if track.artists is None
+            else [str(artist.id) for artist in track.artists]
+        )
+        name = "" if track.name is None else track.name
+        date_added = (
+            None
+            if track.user_date_added is None
+            else track.user_date_added.replace(microsecond=0)
+        )
+
         return cls(
-            track_id="" if track.id is None else str(track.id),
-            artist_id=(
-                ""
-                if track.artist is None or track.artist.id is None
-                else str(track.artist.id)
-            ),
-            name="" if track.name is None else track.name,
-            date_added=(
-                None
-                if track.user_date_added is None
-                else track.user_date_added.replace(microsecond=0)
-            ),
+            track_id=track_id,
+            artist_ids=artist_ids,
+            name=name,
+            date_added=date_added,
             origin=Origin.TIDAL,
         )

--- a/tests/unittests/entity/test_track.py
+++ b/tests/unittests/entity/test_track.py
@@ -26,7 +26,7 @@ def test_track_from_spotify(spotify_track):
     track = Track.from_spotify(spotify_track)
 
     assert track.track_id == "2yTFrY6qG6l46rfVtQDVim"
-    assert track.artist_id == "7G1GBhoKtEPnP86X2PvEYO"
+    assert track.artist_ids == ["7G1GBhoKtEPnP86X2PvEYO", "586uxXMyD5ObPuzjtrzO1Q"]
     assert track.name == "Sinnerman - Sofi Tukker Remix"
     assert track.date_added == dt(2024, 2, 10, 14, 17, 45).replace(
         tzinfo=pytz.utc
@@ -38,7 +38,7 @@ def test_track_from_tidal(tidal_track):
     track = Track.from_tidal(tidal_track)
 
     assert track.track_id == "123456789"
-    assert track.artist_id == "18272666"
+    assert track.artist_ids == ["18272666"]
     assert track.name == "Ovni"
     assert track.date_added == dt(2023, 12, 29, 16, 0, 34).replace(
         tzinfo=pytz.utc


### PR DESCRIPTION
Changes `Track.artist_id` to `Track.artist_ids` storing multiple artist IDs as a list of artist IDs.

This fixes #1.