### PR TITLE
Change to Slotted and Frozen Dataclasses

### DIFF
--- a/musync/entity/artist.py
+++ b/musync/entity/artist.py
@@ -7,7 +7,7 @@ import tidalapi as tidal
 from musync.entity.origin import Origin
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class Artist:
     artist_id: str
     name: str

--- a/musync/entity/playlist.py
+++ b/musync/entity/playlist.py
@@ -7,7 +7,7 @@ import tidalapi as tidal
 from musync.entity.origin import Origin
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class Playlist:
     playlist_id: str
     owner_id: str

--- a/musync/entity/track.py
+++ b/musync/entity/track.py
@@ -12,7 +12,7 @@ from musync.entity.origin import Origin
 from musync.entity.utils import normalize_str
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class Track:
     track_id: str
     artist_ids: list[str]

--- a/musync/entity/user.py
+++ b/musync/entity/user.py
@@ -7,7 +7,7 @@ import tidalapi as tidal
 from musync.entity.origin import Origin
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class User:
     user_id: str
     name: str


### PR DESCRIPTION
This changes the entity classes to frozen and slotted. As there is no usage of the entity classes that conflicts with those setting, frozen slots are the more conservative default option.

This fixes #5.